### PR TITLE
Fix deprecated request.is_ajax() call

### DIFF
--- a/gdpr_solution/views.py
+++ b/gdpr_solution/views.py
@@ -13,7 +13,7 @@ from .models import CookieConsentLog
 # Create your views here.
 class CookieCreateView(View):
     def post(self, request, **kwargs):
-        if request.is_ajax():
+        if (request.META.get('HTTP_X_REQUESTED_WITH') == 'XMLHttpRequest'):
             cookie_preferences = request.POST.get('user_preferences')
             cookie_from_url = request.POST.get('request_url')
 


### PR DESCRIPTION
16.                if request.is_ajax():     is deprecated starting with Django 3.1 and not working anymore in Django 4.0.
It should be replaced with  if (request.META.get('HTTP_X_REQUESTED_WITH') == 'XMLHttpRequest'):